### PR TITLE
implementar as validações de cadastro em processo e interessado

### DIFF
--- a/grupo5/pom.xml
+++ b/grupo5/pom.xml
@@ -64,7 +64,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>5.3.1.Final</version>
+		</dependency>
 		<dependency>
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>

--- a/grupo5/src/main/java/br/com/devinhouse/grupo5/model/Interessado.java
+++ b/grupo5/src/main/java/br/com/devinhouse/grupo5/model/Interessado.java
@@ -9,6 +9,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.hibernate.validator.constraints.br.CPF;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +30,7 @@ public class Interessado {
 	private Long id;
 	@Column(length = 250, nullable = false)
 	private String nmInteressado;
+	@CPF
 	@Column(length = 50, nullable = false)
 	private String nuIdentificacao;
 	@Column(nullable = false)

--- a/grupo5/src/main/java/br/com/devinhouse/grupo5/repository/RepositorioDeInteressado.java
+++ b/grupo5/src/main/java/br/com/devinhouse/grupo5/repository/RepositorioDeInteressado.java
@@ -8,4 +8,6 @@ import br.com.devinhouse.grupo5.model.Interessado;
 
 public interface RepositorioDeInteressado extends JpaRepository<Interessado, Long> {
 	Optional<Interessado> findByNuIdentificacao(String nuIdentificacao);
+
+	Boolean existsByNuIdentificacao(String nuIdentificacao);
 }

--- a/grupo5/src/main/java/br/com/devinhouse/grupo5/repository/RepositorioDeProcessos.java
+++ b/grupo5/src/main/java/br/com/devinhouse/grupo5/repository/RepositorioDeProcessos.java
@@ -18,4 +18,6 @@ public interface RepositorioDeProcessos extends JpaRepository<Processo, Long> {
 	Optional<Processo> findByNuProcesso(Integer nuProcesso);
 
 	Boolean existsByNuProcesso(Integer nuProcesso);
+	
+	Boolean existsByChaveProcesso(String chaveProcesso);
 }

--- a/grupo5/src/main/java/br/com/devinhouse/grupo5/service/InteressadoService.java
+++ b/grupo5/src/main/java/br/com/devinhouse/grupo5/service/InteressadoService.java
@@ -19,6 +19,16 @@ public class InteressadoService {
     ModelMapper modelMapper;
     
     public InteressadoOutputDTO cadastrarInteressado(InteressadoInputDTO novoInteressado) {
+		// 1 - Não poderá ser cadastrado um novo interessado com um id já existente;
+    	var interessado = buscarInteressadoPeloId(novoInteressado.getId());
+    	if (interessado != null) {
+    		throw new InteressadoNaoEncontradoException("Há um interessado cadastrado com o mesmo ID.");
+    	}
+		// 2 - Não poderá ser cadastrado um novo interessado com um mesmo documento de indentificação;
+    	Boolean existNuIdentificacao = repositorioDeInteressado.existsByNuIdentificacao(novoInteressado.getNuIdentificacao());
+    	if (Boolean.TRUE.equals(existNuIdentificacao)) {
+    		throw new InteressadoNaoEncontradoException("A identificação informada já está cadastrada.");
+    	}
         return toDTO(repositorioDeInteressado.save(toInteressado(novoInteressado)));
     }
 


### PR DESCRIPTION
Foi implementado as seguintes validações:

3 - Não poderá ser cadastrado um novo processo com interessados inativos;
4 - Não poderá ser cadastrado um novo processo com assuntos inativos;
5 - Não poderá ser cadastrado um novo processo com interessados inexistentes no sistema;
6 - Não poderá ser cadastrado um novo processo com assuntos inexistentes no sistema;
7 - Não poderá ser cadastrado um novo interessado com um id já existente;
8 - Não poderá ser cadastrado um novo interessado com um mesmo documento de identificação;
9 - Não poderá ser cadastrado um novo interessado com um documento de identificação inválido;
